### PR TITLE
Add note for local trigger run requirement

### DIFF
--- a/docs/production/event-triggering/flow-events.md
+++ b/docs/production/event-triggering/flow-events.md
@@ -151,4 +151,9 @@ This will run the flow as if it was triggered by a run `ModelRefreshFlow/233`.
 This allows you to quickly iterate on the flow locally, testing it with
 different upstream data providers.
 
+:::note
+In order for the trigger to succeed, the run `ModelRefreshFlow/233` must be an actual run that exists.
+Metaflow will raise an error if a nonexistent run is specified.
+:::
+
 


### PR DESCRIPTION
I was testing [local flow triggering](https://docs.metaflow.org/production/event-triggering/flow-events#testing-flow-triggering-locally) and I noticed that I couldn't make up data for the run id - it had to be an actual existing run.  It would be nice to call this out to avoid confusion (I initially thought "as if it were triggered by a run `ModelRefreshFlow/233`" meant that I could make up my own run id, which was not the case)